### PR TITLE
Feature/api list applications endpoint

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -2,17 +2,17 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ListApplicationsRequest;
 use App\Models\Application;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 class ApplicationController extends Controller
 {
     /**
      * Return a list of applications.
      */
-    public function index(Request $request): JsonResponse
+    public function index(ListApplicationsRequest $request): JsonResponse
     {
-        $planType = $request->query('planType');
+        $planType = $request->query('plan_type');
 
         $applications = Application::when($planType, fn ($query) => $query->planType($planType))
             ->orderBy('created_at')

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Application;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+class ApplicationController extends Controller
+{
+    /**
+     * Return a list of applications.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $planType = $request->query('planType');
+
+        $applications = Application::when($planType, fn ($query) => $query->planType($planType))
+            ->orderBy('created_at')
+            ->paginate(10);
+
+        return response()->json($applications);
+    }
+}

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -3,21 +3,23 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ListApplicationsRequest;
+use App\Http\Resources\ApplicationResource;
 use App\Models\Application;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
 class ApplicationController extends Controller
 {
     /**
      * Return a list of applications.
      */
-    public function index(ListApplicationsRequest $request): JsonResponse
+    public function index(ListApplicationsRequest $request): AnonymousResourceCollection
     {
         $planType = $request->query('plan_type');
 
         $applications = Application::when($planType, fn ($query) => $query->planType($planType))
             ->orderBy('created_at')
-            ->paginate(10);
+            ->paginate(config('pagination.api.pagination.per_page'));
 
-        return response()->json($applications);
+        return ApplicationResource::collection($applications);
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/app/Http/Requests/ListApplicationsRequest.php
+++ b/app/Http/Requests/ListApplicationsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ListApplicationsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'plan_type' => [
+                'nullable',
+                'string',
+                Rule::in(['nbn', 'mobile', 'opticomm']),
+            ],
+        ];
+    }
+}
+

--- a/app/Http/Resources/ApplicationResource.php
+++ b/app/Http/Resources/ApplicationResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Enums\ApplicationStatus;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ApplicationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'application_id' => $this->id,
+            'customer_name' => $this->customer->full_name,
+            'address' => $this->full_address,
+            'state' => $this->state,
+            'plan_type' => $this->plan->type,
+            'plan_name' => $this->plan->name,
+            'plan_monthly_cost' => $this->plan->monthly_cost_formatted,
+            'order_id' => $this->when($this->status === ApplicationStatus::Complete, $this->order_id),
+        ];
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -6,6 +6,7 @@ use App\Enums\ApplicationStatus;
 use App\Events\ApplicationCreated;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Application extends Model
 {
@@ -18,4 +19,9 @@ class Application extends Model
     protected $dispatchesEvents = [
         'created' => ApplicationCreated::class,
     ];
+
+    public function plan(): BelongsTo
+    {
+        return $this->belongsTo(Plan::class);
+    }
 }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\ApplicationStatus;
 use App\Events\ApplicationCreated;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -23,5 +24,13 @@ class Application extends Model
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class);
+    }
+
+    /**
+     * Scope a query to only include applications with a plan of a given type.
+     */
+    public function scopePlanType(Builder $query, string $planType): Builder
+    {
+        return $query->whereHas('plan', fn ($query) => $query->where('type', $planType));
     }
 }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Application extends Model
 {
@@ -26,11 +27,34 @@ class Application extends Model
         return $this->belongsTo(Plan::class);
     }
 
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
     /**
      * Scope a query to only include applications with a plan of a given type.
      */
     public function scopePlanType(Builder $query, string $planType): Builder
     {
         return $query->whereHas('plan', fn ($query) => $query->where('type', $planType));
+    }
+
+    /**
+     * Get the full address of the application.
+     */
+    protected function fullAddress(): Attribute
+    {
+        $fields = [
+            $this->address_1,
+            $this->address_2,
+            $this->city,
+            $this->state,
+            $this->postcode,
+        ];
+
+        return Attribute::make(
+            get: fn () => implode(', ', array_filter($fields)),
+        );
     }
 }

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -37,7 +37,7 @@ class Application extends Model
      */
     public function scopePlanType(Builder $query, string $planType): Builder
     {
-        return $query->whereHas('plan', fn ($query) => $query->where('type', $planType));
+        return $query->withWhereHas('plan', fn ($query) => $query->where('type', $planType));
     }
 
     /**

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -2,10 +2,27 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Customer extends Model
 {
     use HasFactory;
+
+    public function applications(): HasMany
+    {
+        return $this->hasMany(Application::class);
+    }
+
+    /**
+     * Get the full name of the customer.
+     */
+    protected function fullName(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->first_name . ' ' . $this->last_name,
+        );
+    }
 }

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -21,8 +21,10 @@ class Plan extends Model
      */
     protected function monthlyCostFormatted(): Attribute
     {
+        $prefix = '$';
+        
         return Attribute::make(
-            get: fn () => number_format($this->monthly_cost / 100, 2),
+            get: fn () => $prefix . number_format($this->monthly_cost / 100, 2),
         );
     }
 }

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -2,10 +2,27 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Plan extends Model
 {
     use HasFactory;
+
+    public function applications(): HasMany
+    {
+        return $this->hasMany(Application::class);
+    }
+
+    /**
+     * Get the monthly cost of the plan in human readable format.
+     */
+    protected function monthlyCostFormatted(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => number_format($this->monthly_cost / 100, 2),
+        );
+    }
 }

--- a/config/pagination.php
+++ b/config/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Pagination
+    |--------------------------------------------------------------------------
+    |
+    | This configuration is used to set the pagination settings for the API endpoints.
+    |
+    */
+
+    'api' => [
+        'pagination' => [
+            'per_page' => 20,
+        ],
+    ],
+];

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -22,4 +22,28 @@ class PlanFactory extends Factory
             'monthly_cost' => $this->faker->numerify('####'),
         ];
     }
+
+    /**
+     * Return a plan with the type of `opticomm`.
+     */
+    public function opticomm(): self
+    {
+        return $this->state(fn () => ['type' => 'opticomm']);
+    }
+
+    /**
+     * Return a plan with the type of `mobile`.
+     */
+    public function mobile(): self
+    {
+        return $this->state(fn () => ['type' => 'mobile']);
+    }
+
+    /**
+     * Return a plan with the type of `nbn`.
+     */
+    public function nbn(): self
+    {
+        return $this->state(fn () => ['type' => 'nbn']);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,5 +16,5 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->group(function () {  
     Route::get('/user', fn () => auth()->user());
-    Route::get('/applications', [ApplicationController::class, 'index'])->name('api.applications');
+    Route::get('/applications', [ApplicationController::class, 'index'])->name('api.v1.applications.index');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ApplicationController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -16,4 +17,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::middleware('auth:sanctum')->group(function () {  
+    Route::get('/applications', [ApplicationController::class, 'index'])->name('api.applications');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Http\Controllers\ApplicationController;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -15,10 +14,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
-});
-
 Route::middleware('auth:sanctum')->group(function () {  
+    Route::get('/user', fn () => auth()->user());
     Route::get('/applications', [ApplicationController::class, 'index'])->name('api.applications');
 });

--- a/tests/Feature/Application/ApiTest.php
+++ b/tests/Feature/Application/ApiTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Application;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class ApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+
+        $this->actingAs($this->user);
+        $this->assertAuthenticated();
+    }
+
+    public function test_should_return_an_empty_response_when_no_applications_are_found(): void
+    {
+        $response = $this->sendRequest();
+
+        $response->assertSuccessful();
+        $response->assertJson(['total' => 0]);
+    }
+
+    /**
+     * Send the GET request to the API endpoint.
+     */
+    private function sendRequest(?string $planType = null): TestResponse
+    {
+        $queryParams = $planType ? ['planType' => $planType] : [];
+
+        return $this->getJson(route('api.applications', $queryParams));
+    }
+}
+

--- a/tests/Feature/Application/ApiTest.php
+++ b/tests/Feature/Application/ApiTest.php
@@ -37,6 +37,14 @@ class ApiTest extends TestCase
         $response->assertJson(['total' => 0]);
     }
 
+    public function test_should_return_a_validation_error_when_invalid_plan_type_is_provided(): void
+    {
+        $response = $this->sendRequest('invalid_plan_type');
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['plan_type']);
+    }
+
     #[DataProvider('applicationsDataProvider')]
     public function test_should_return_a_paginated_response_when_applications_are_found(Closure $planFactory): void
     {
@@ -95,7 +103,7 @@ class ApiTest extends TestCase
      */
     private function sendRequest(?string $planType = null): TestResponse
     {
-        $queryParams = $planType ? ['planType' => $planType] : [];
+        $queryParams = $planType ? ['plan_type' => $planType] : [];
 
         return $this->getJson(route('api.applications', $queryParams));
     }

--- a/tests/Feature/Application/ApiTest.php
+++ b/tests/Feature/Application/ApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Application;
 
+use App\Enums\ApplicationStatus;
 use App\Models\Application;
 use App\Models\Plan;
 use App\Models\User;
@@ -9,6 +10,7 @@ use Closure;
 use Database\Factories\PlanFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
@@ -29,12 +31,29 @@ class ApiTest extends TestCase
         $this->assertAuthenticated();
     }
 
+    public function test_should_return_the_pagination_meta_data(): void
+    {
+        $applications = Application::factory()->count(5)->create();
+
+        $response = $this->sendRequest();
+
+        $response->assertSuccessful();
+        $response->assertJson(fn (AssertableJson $json) =>
+            $json->has('meta')
+                ->where('meta.current_page', 1)
+                ->where('meta.last_page', 1)
+                ->where('meta.per_page', config('pagination.api.pagination.per_page', 15))
+                ->where('meta.total', $applications->count())
+                ->etc()
+        );
+    }
+
     public function test_should_return_an_empty_response_when_no_applications_are_found(): void
     {
         $response = $this->sendRequest();
 
         $response->assertSuccessful();
-        $response->assertJson(['total' => 0]);
+        $response->assertJsonCount(0, 'data');
     }
 
     public function test_should_return_a_validation_error_when_invalid_plan_type_is_provided(): void
@@ -45,21 +64,62 @@ class ApiTest extends TestCase
         $response->assertJsonValidationErrors(['plan_type']);
     }
 
-    #[DataProvider('applicationsDataProvider')]
-    public function test_should_return_a_paginated_response_when_applications_are_found(Closure $planFactory): void
+    #[DataProvider('planTypeFiltersDataProvider')]
+    public function test_should_return_the_applications_filtered_by_plan_type(Closure $planFactory): void
     {
         // Create a new plan based on the data provider
         $plan = $planFactory()->create();
         
+        // Create two applications with different statuses
         $applications = Application::factory()
-            ->count(10)
+            ->count(2)
             ->recycle($plan)
-            ->create();
+            ->create([
+                'status' => new Sequence(ApplicationStatus::Prelim, ApplicationStatus::Complete),
+            ]);
+
+        $preliminaryApplication = $applications->firstWhere('status', ApplicationStatus::Prelim);
+        $completeApplication = $applications->firstWhere('status', ApplicationStatus::Complete);
 
         $response = $this->sendRequest($plan->type);
 
         $response->assertSuccessful();
-        $response->assertJson(['total' => $applications->count()]);
+        $response->assertJson(fn (AssertableJson $json) =>
+            $json->has('data', $applications->count())
+                 ->has('data.0', fn (AssertableJson $json) =>
+                    $json->where('application_id', $preliminaryApplication->id)
+                        ->where('customer_name', $preliminaryApplication->customer->full_name)
+                        ->where('address', $preliminaryApplication->full_address)
+                        ->where('state', $preliminaryApplication->state)
+                        ->where('plan_type', $preliminaryApplication->plan->type)
+                        ->where('plan_name', $preliminaryApplication->plan->name)
+                        ->where('plan_monthly_cost', $preliminaryApplication->plan->monthly_cost_formatted)
+                        ->missing('order_id')
+                        ->etc()
+                )
+                 ->has('data.1', fn (AssertableJson $json) =>
+                    $json->where('application_id', $completeApplication->id)
+                        ->where('customer_name', $completeApplication->customer->full_name)
+                        ->where('address', $completeApplication->full_address)
+                        ->where('state', $completeApplication->state)
+                        ->where('plan_type', $completeApplication->plan->type)
+                        ->where('plan_name', $completeApplication->plan->name)
+                        ->where('plan_monthly_cost', $completeApplication->plan->monthly_cost_formatted)
+                        ->has('order_id')
+                        ->etc()
+                )
+                 ->etc()
+        );
+    }
+
+    public function test_should_return_the_applications_without_any_filter(): void
+    {
+        $applications = Application::factory()->count(5)->create();
+
+        $response = $this->sendRequest();
+
+        $response->assertSuccessful();
+        $response->assertJsonCount($applications->count(), 'data');
     }
 
     public function test_should_return_the_applications_sorted_by_oldest_first(): void
@@ -69,30 +129,43 @@ class ApiTest extends TestCase
             ->count(2)
             ->create([
                 'created_at' => new Sequence(now()->subDays(2), now())
-            ]);
+            ])
+            ->sortBy('created_at')
+            ->values();
+            
+        $oldestApplication = $applications->first();
+        $latestApplication = $applications->last();
 
         $response = $this->sendRequest();
 
         $response->assertSuccessful();
-        $response->assertJson(['total' => $applications->count()]);
-        $response->assertJsonPath('data.0.id', $applications->first()->id);
-        $response->assertJsonPath('data.1.id', $applications->last()->id);
-
+        $response->assertJson(fn (AssertableJson $json) =>
+            $json->has('data', $applications->count())
+                 ->has('data.0', fn (AssertableJson $json) =>
+                    $json->where('application_id', $oldestApplication->id)
+                        ->etc()
+                )
+                 ->has('data.1', fn (AssertableJson $json) =>
+                    $json->where('application_id', $latestApplication->id)
+                        ->etc()
+                )
+                 ->etc()
+        );
     }
 
     /**
      * Data provider with different plan types.
      */
-    public static function applicationsDataProvider(): array
+    public static function planTypeFiltersDataProvider(): array
     {
         return [
-            'Search by mobile plan' => [
+            'Filter by mobile plan' => [
                 'plan' => fn () : PlanFactory => Plan::factory()->mobile(),
             ],
-            'Search by NBN plan' => [
+            'Filter by NBN plan' => [
                 'plan' => fn () : PlanFactory => Plan::factory()->nbn(),
             ],
-            'Search by Opticomm plan' => [
+            'Filter by Opticomm plan' => [
                 'plan' => fn () : PlanFactory => Plan::factory()->opticomm(),
             ],
         ];
@@ -105,7 +178,7 @@ class ApiTest extends TestCase
     {
         $queryParams = $planType ? ['plan_type' => $planType] : [];
 
-        return $this->getJson(route('api.applications', $queryParams));
+        return $this->getJson(route('api.v1.applications.index', $queryParams));
     }
 }
 

--- a/tests/Feature/Application/ApiTest.php
+++ b/tests/Feature/Application/ApiTest.php
@@ -17,7 +17,7 @@ class ApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected User $user;
+    private User $user;
 
     public function setUp(): void
     {

--- a/tests/Feature/Application/ApiTest.php
+++ b/tests/Feature/Application/ApiTest.php
@@ -7,6 +7,7 @@ use App\Models\Plan;
 use App\Models\User;
 use Closure;
 use Database\Factories\PlanFactory;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -51,6 +52,24 @@ class ApiTest extends TestCase
 
         $response->assertSuccessful();
         $response->assertJson(['total' => $applications->count()]);
+    }
+
+    public function test_should_return_the_applications_sorted_by_oldest_first(): void
+    {
+        // Create two applications with different `created_at` dates
+        $applications = Application::factory()
+            ->count(2)
+            ->create([
+                'created_at' => new Sequence(now()->subDays(2), now())
+            ]);
+
+        $response = $this->sendRequest();
+
+        $response->assertSuccessful();
+        $response->assertJson(['total' => $applications->count()]);
+        $response->assertJsonPath('data.0.id', $applications->first()->id);
+        $response->assertJsonPath('data.1.id', $applications->last()->id);
+
     }
 
     /**

--- a/tests/Unit/FormRequest/ListApplicationsRequestTest.php
+++ b/tests/Unit/FormRequest/ListApplicationsRequestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\FormRequest;
+
+use App\Http\Requests\ListApplicationsRequest;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class ListApplicationsRequestTest extends TestCase
+{
+    use WithFaker;
+
+    private ListApplicationsRequest $request;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request = new ListApplicationsRequest();
+    }
+
+    public function test_should_pass_with_valid_plan_type(): void
+    {
+        $planType = $this->faker->randomElement(['nbn', 'mobile', 'opticomm']);
+
+        $data = [
+            'plan_type' => $planType,
+        ];
+
+        $validator = Validator::make($data, $this->request->rules());
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function test_should_fail_with_invalid_plan_type(): void
+    {
+        $data = [
+            'plan_type' => 'invalid_plan_type',
+        ];
+
+        $validator = Validator::make($data, $this->request->rules());
+
+        $this->assertFalse($validator->passes());
+        $this->assertArrayHasKey('plan_type', $validator->errors()->toArray());
+    }
+}

--- a/tests/Unit/FormRequest/ListApplicationsRequestTest.php
+++ b/tests/Unit/FormRequest/ListApplicationsRequestTest.php
@@ -20,6 +20,15 @@ class ListApplicationsRequestTest extends TestCase
         $this->request = new ListApplicationsRequest();
     }
 
+    public function test_should_pass_without_any_plan_type(): void
+    {
+        $data = [];
+
+        $validator = Validator::make($data, $this->request->rules());
+
+        $this->assertTrue($validator->passes());
+    }
+
     public function test_should_pass_with_valid_plan_type(): void
     {
         $planType = $this->faker->randomElement(['nbn', 'mobile', 'opticomm']);

--- a/tests/Unit/Models/ApplicationTest.php
+++ b/tests/Unit/Models/ApplicationTest.php
@@ -14,4 +14,23 @@ class ApplicationTest extends TestCase
 
         $this->assertInstanceOf(Plan::class, $application->plan);
     }
+
+    public function test_should_return_the_correct_applications_when_filtering_by_plan_type(): void
+    {
+        // Create two applications with different plan types
+        $nbnApplication = Application::factory()->for(Plan::factory()->nbn())->create();
+        $mobileApplication = Application::factory()->for(Plan::factory()->mobile())->create();
+
+        // Filter by `nbn` plan type
+        $result = Application::planType('nbn')->get();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($nbnApplication->id, $result->first()->id);
+
+        // Filter by `mobile` plan type
+        $result = Application::planType('mobile')->get();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals($mobileApplication->id, $result->first()->id);
+    }
 }

--- a/tests/Unit/Models/ApplicationTest.php
+++ b/tests/Unit/Models/ApplicationTest.php
@@ -42,7 +42,7 @@ class ApplicationTest extends TestCase
 
     public function test_should_return_the_full_address_of_the_application(): void
     {
-        $application = Application::factory()->create([
+        $application = Application::factory()->make([
             'address_1' => $this->faker->streetAddress(),
             'address_2' => $this->faker->secondaryAddress(),
             'city' => $this->faker->city(),
@@ -58,6 +58,6 @@ class ApplicationTest extends TestCase
             $application->postcode,
         ]));
 
-        $this->assertEquals($application->full_address, $expectedAddress);
+        $this->assertEquals($expectedAddress, $application->full_address);
     }
 }

--- a/tests/Unit/Models/ApplicationTest.php
+++ b/tests/Unit/Models/ApplicationTest.php
@@ -3,16 +3,22 @@
 namespace Tests\Unit\Models;
 
 use App\Models\Application;
+use App\Models\Customer;
 use App\Models\Plan;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class ApplicationTest extends TestCase
 {
+    use RefreshDatabase, WithFaker;
+
     public function test_should_return_the_correct_relationships(): void
     {
         $application = Application::factory()->create();
 
         $this->assertInstanceOf(Plan::class, $application->plan);
+        $this->assertInstanceOf(Customer::class, $application->customer);
     }
 
     public function test_should_return_the_correct_applications_when_filtering_by_plan_type(): void
@@ -32,5 +38,26 @@ class ApplicationTest extends TestCase
 
         $this->assertCount(1, $result);
         $this->assertEquals($mobileApplication->id, $result->first()->id);
+    }
+
+    public function test_should_return_the_full_address_of_the_application(): void
+    {
+        $application = Application::factory()->create([
+            'address_1' => $this->faker->streetAddress(),
+            'address_2' => $this->faker->secondaryAddress(),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->state(),
+            'postcode' => $this->faker->postcode(),
+        ]);
+
+        $expectedAddress = implode(', ', array_filter([
+            $application->address_1,
+            $application->address_2,
+            $application->city,
+            $application->state,
+            $application->postcode,
+        ]));
+
+        $this->assertEquals($application->full_address, $expectedAddress);
     }
 }

--- a/tests/Unit/Models/ApplicationTest.php
+++ b/tests/Unit/Models/ApplicationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Application;
+use App\Models\Plan;
+use Tests\TestCase;
+
+class ApplicationTest extends TestCase
+{
+    public function test_should_return_the_correct_relationships(): void
+    {
+        $application = Application::factory()->create();
+
+        $this->assertInstanceOf(Plan::class, $application->plan);
+    }
+}

--- a/tests/Unit/Models/CustomerTest.php
+++ b/tests/Unit/Models/CustomerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Application;
+use App\Models\Customer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class CustomerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function test_should_return_the_correct_relationships(): void
+    {
+        $customer = Customer::factory()->hasApplications()->create();
+
+        $this->assertInstanceOf(Collection::class, $customer->applications);
+        $this->assertInstanceOf(Application::class, $customer->applications->first());
+    }
+
+    public function test_should_return_the_full_name_of_the_customer(): void
+    {
+        $customer = Customer::factory()->create(['first_name' => 'John', 'last_name' => 'Doe']);
+
+        $this->assertEquals('John Doe', $customer->full_name);
+    }
+}

--- a/tests/Unit/Models/CustomerTest.php
+++ b/tests/Unit/Models/CustomerTest.php
@@ -23,7 +23,7 @@ class CustomerTest extends TestCase
 
     public function test_should_return_the_full_name_of_the_customer(): void
     {
-        $customer = Customer::factory()->create(['first_name' => 'John', 'last_name' => 'Doe']);
+        $customer = Customer::factory()->state(['first_name' => 'John', 'last_name' => 'Doe'])->make();
 
         $this->assertEquals('John Doe', $customer->full_name);
     }

--- a/tests/Unit/Models/PlanTest.php
+++ b/tests/Unit/Models/PlanTest.php
@@ -26,6 +26,6 @@ class PlanTest extends TestCase
         // Create a plan with a monthly cost of $100.00
         $plan = Plan::factory()->create(['monthly_cost' => 10000]);
 
-        $this->assertEquals('100.00', $plan->monthly_cost_formatted);
+        $this->assertEquals('$100.00', $plan->monthly_cost_formatted);
     }
 }

--- a/tests/Unit/Models/PlanTest.php
+++ b/tests/Unit/Models/PlanTest.php
@@ -24,7 +24,7 @@ class PlanTest extends TestCase
     public function test_should_return_the_monthly_cost_of_the_plan_in_human_readable_format(): void
     {
         // Create a plan with a monthly cost of $100.00
-        $plan = Plan::factory()->create(['monthly_cost' => 10000]);
+        $plan = Plan::factory()->state(['monthly_cost' => 10000])->make();
 
         $this->assertEquals('$100.00', $plan->monthly_cost_formatted);
     }

--- a/tests/Unit/Models/PlanTest.php
+++ b/tests/Unit/Models/PlanTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Application;
+use App\Models\Plan;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class PlanTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function test_should_return_the_correct_relationships(): void
+    {
+        $plan = Plan::factory()->hasApplications()->create();
+
+        $this->assertInstanceOf(Collection::class, $plan->applications);
+        $this->assertInstanceOf(Application::class, $plan->applications->first());
+    }
+
+    public function test_should_return_the_monthly_cost_of_the_plan_in_human_readable_format(): void
+    {
+        // Create a plan with a monthly cost of $100.00
+        $plan = Plan::factory()->create(['monthly_cost' => 10000]);
+
+        $this->assertEquals('100.00', $plan->monthly_cost_formatted);
+    }
+}

--- a/tests/Unit/Resources/ApplicationResourceTest.php
+++ b/tests/Unit/Resources/ApplicationResourceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Resources;
+
+use App\Enums\ApplicationStatus;
+use App\Http\Resources\ApplicationResource;
+use App\Models\Application;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Resources\MissingValue;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class ApplicationResourceTest extends TestCase
+{
+    use WithFaker;
+
+    #[DataProvider('applicationStatusProvider')]
+    public function test_should_return_the_correct_transformed_data_for_different_application_statuses(ApplicationStatus $status): void
+    {
+        $application = Application::factory()->state(['status' => $status])->make();
+
+        $resource = (new ApplicationResource($application))->toArray(request());
+
+        $this->assertEquals($this->getExpectedData($application), $resource);
+    }
+
+    /**
+     * Data provider with different application statuses.
+     */
+    public static function applicationStatusProvider(): array
+    {
+        return [
+            'Prelim status' => [
+                'status' => ApplicationStatus::Prelim,
+            ],
+            'Complete status' => [
+                'status' => ApplicationStatus::Complete,
+            ],
+        ];
+    }
+
+    /**
+     * Get the expected data based on the application status.
+     */
+    private function getExpectedData(Application $application): array
+    {
+        $data = [
+            'application_id' => $application->id,
+            'customer_name' => $application->customer->full_name,
+            'address' => $application->full_address,
+            'state' => $application->state,
+            'plan_type' => $application->plan->type,
+            'plan_name' => $application->plan->name,
+            'plan_monthly_cost' => $application->plan->monthly_cost_formatted,
+            'order_id' => $application->status === ApplicationStatus::Complete ? $application->order_id : new MissingValue,
+        ];
+
+        return $data;
+    }
+}

--- a/tests/Unit/Resources/ApplicationResourceTest.php
+++ b/tests/Unit/Resources/ApplicationResourceTest.php
@@ -17,7 +17,7 @@ class ApplicationResourceTest extends TestCase
     #[DataProvider('applicationStatusProvider')]
     public function test_should_return_the_correct_transformed_data_for_different_application_statuses(ApplicationStatus $status): void
     {
-        $application = Application::factory()->state(['status' => $status])->make();
+        $application = Application::factory()->state(['status' => $status])->create();
 
         $resource = (new ApplicationResource($application))->toArray(request());
 


### PR DESCRIPTION
**What does this PR do?**

This PR implements a new API endpoint (Task 1) that allows authenticated users to retrieve a paginated list of applications. The users can optionally filter the applications by plan type (nbn, opticomm, or mobile).

**Key Changes:**

- Create the controller and the action to handle the API endpoint;
- Create a new FormRequest file to validate the request payload;
- Create a new API Resource to isolate the logic to build the response data;
- Create a new config file to store the pagination setting (number of items per page);
- Create the model relationships and accessors (monthly cost, full address and full name) in different models;
- Implement unit and feature tests to cover different areas of the system.

The API endpoint should now be paginated and only accessible for authenticated users.

**Additional Information:**

![Screenshot 2025-02-06 at 10 50 55 pm](https://github.com/user-attachments/assets/377a1274-a5ad-4c06-ad25-e04d86d249ce)
