### PR TITLE
Refactor: remove the 'withWhereHas' that was only applied when there …

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -17,6 +17,10 @@ class ApplicationController extends Controller
         $planType = $request->query('plan_type');
 
         $applications = Application::when($planType, fn ($query) => $query->planType($planType))
+            ->with([
+                'customer' => fn ($query) => $query->select(['id', 'first_name', 'last_name']),
+                'plan' => fn ($query) => $query->select(['id', 'type', 'name', 'monthly_cost']),
+            ])
             ->orderBy('created_at')
             ->paginate(config('pagination.api.pagination.per_page'));
 

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -37,7 +37,7 @@ class Application extends Model
      */
     public function scopePlanType(Builder $query, string $planType): Builder
     {
-        return $query->withWhereHas('plan', fn ($query) => $query->where('type', $planType));
+        return $query->whereHas('plan', fn ($query) => $query->where('type', $planType));
     }
 
     /**


### PR DESCRIPTION
**What does this PR do?**

After doing my own review in the previous PR, I realise the `Application` model was only eager loading the `Plan` conditionally. As the application always have a plan and it's used in the API Resource, the relationship needs to be always eager loaded. I also made a small improvement by selecting only relevant columns from each related table.