### PR TITLE
Add(job): Implement the 'ShouldBeUnique' interface and define the uni…

### DIFF
--- a/app/Jobs/ProcessNbnOrder.php
+++ b/app/Jobs/ProcessNbnOrder.php
@@ -6,6 +6,7 @@ use App\Enums\ApplicationStatus;
 use App\Models\Application;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -13,7 +14,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
-class ProcessNbnOrder implements ShouldQueue
+class ProcessNbnOrder implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -78,6 +79,22 @@ class ProcessNbnOrder implements ShouldQueue
         ]);
 
         $this->application->update(['status' => ApplicationStatus::OrderFailed]);
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return $this->application->id;
+    }
+
+    /**
+     * Ensure the job stays unique for 10 minutes (to prevent accidental re-processing).
+     */
+    public function uniqueFor(): int
+    {
+        return 10 * 60; // 10 minutes
     }
 
     /**

--- a/tests/Unit/Jobs/ProcessNbnOrderTest.php
+++ b/tests/Unit/Jobs/ProcessNbnOrderTest.php
@@ -51,6 +51,16 @@ class ProcessNbnOrderTest extends TestCase
         $this->assertEquals($response['id'], $this->application->order_id);
     }
 
+    public function test_should_not_dispatch_duplicate_jobs_for_the_same_application(): void
+    {
+        // Dispatch the same job twice
+        ProcessNbnOrder::dispatch($this->application);
+        ProcessNbnOrder::dispatch($this->application);
+
+        // Assert that only `one unique` job was dispatched
+        Queue::assertPushed(ProcessNbnOrder::class, 1);
+    }
+
     public function test_should_set_status_to_order_failed_on_failed_response(): void
     {
         $response = $this->getFailedResponse();
@@ -86,6 +96,7 @@ class ProcessNbnOrderTest extends TestCase
         // Ensure the application status remains unchanged
         $this->assertEquals(ApplicationStatus::Complete, $applicationAlreadyProcessed->status);
     }
+    
 
     public function test_should_set_application_status_to_failed_when_job_fails(): void
     {


### PR DESCRIPTION
**What does this PR do?**

This PR introduces a unique job ID to prevent duplicate processing of the same application within a short timeframe. It ensures that each job is uniquely identified by the application ID and prevents re-processing for 10 minutes.