### PR TITLE
Add(command): Ensure the command runs without overlapping

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,9 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('orders:process-nbn')->everyFiveMinutes();
+        $schedule->command('orders:process-nbn')
+            ->everyFiveMinutes()
+            ->withoutOverlapping();
     }
 
     /**

--- a/tests/Unit/Commands/ProcessNbnOrderTest.php
+++ b/tests/Unit/Commands/ProcessNbnOrderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Commands;
 
+use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Tests\TestCase;
 
@@ -9,18 +10,30 @@ class ProcessNbnOrderTest extends TestCase
 {
     const COMMAND_NAME = 'orders:process-nbn';
 
-    public function test_should_ensure_the_command_is_registered_and_run_every_five_minutes(): void
+    private Event $event;
+
+    public function setUp(): void
     {
-         // Get the scheduler instance
+        parent::setUp();
+
         $schedule = $this->app->make(Schedule::class);
 
-        // Retrieve all scheduled events
-        $events = collect($schedule->events());
+        // Get the scheduled event for the command
+        $this->event = collect($schedule->events())
+            ->first(
+                fn ($event) => str_contains($event->command, self::COMMAND_NAME)
+            );
 
-        // Find the specific scheduled command
-        $event = $events->first(fn ($event) => str_contains($event->command, self::COMMAND_NAME));
+        $this->assertNotNull($this->event);
+    }
 
-        $this->assertNotNull($event);
-        $this->assertEquals('*/5 * * * *', $event->expression);
+    public function test_should_schedule_process_nbn_orders_without_overlapping(): void
+    {
+        $this->assertTrue($this->event->withoutOverlapping);
+    }
+
+    public function test_should_ensure_the_command_is_registered_and_run_every_five_minutes(): void
+    {
+        $this->assertEquals('*/5 * * * *', $this->event->expression);
     }
 }


### PR DESCRIPTION
**What does this PR do?**

This PR adds **withoutOverlapping()** to the scheduled command to prevent multiple instances from running simultaneously. This ensures that the NBN order processing job does not trigger duplicate executions if a previous instance is still running.

This improvement helps maintain system stability and prevents potential race conditions or unnecessary queue congestion.
